### PR TITLE
Switch to github.com/klauspost/compress/pgzip

### DIFF
--- a/build.go
+++ b/build.go
@@ -2,7 +2,6 @@ package scratchbuild
 
 import (
 	"bytes"
-	"compress/gzip"
 	"fmt"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	_ "crypto/sha256"
 	"encoding/json"
 
+	"github.com/klauspost/pgzip"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -19,7 +19,7 @@ func (c *Client) BuildImage(imageConfig *ImageConfig, layer []byte) error {
 	dig := digest.FromBytes(layer)
 
 	b := &bytes.Buffer{}
-	gw := gzip.NewWriter(b)
+	gw := pgzip.NewWriter(b)
 	if _, err := gw.Write(layer); err != nil {
 		return fmt.Errorf("failed to compress image layer: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/philpearl/scratchbuild
 
 go 1.18
 
-require github.com/opencontainers/go-digest v1.0.0
+require (
+	github.com/klauspost/pgzip v1.2.5
+	github.com/opencontainers/go-digest v1.0.0
+)
+
+require github.com/klauspost/compress v1.16.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
+github.com/klauspost/compress v1.16.5 h1:IFV2oUNUzZaz+XyusxpLzpzS8Pt5rh0Z16For/djlyI=
+github.com/klauspost/compress v1.16.5/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=
+github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=


### PR DESCRIPTION
From casual experiments, I found that there was a noticeable drag with the gzipping part of the code. With one Go binary, I had rough timings as follows for that section:

- github.com/klauspost/pgzip: ~80ms
- github.com/klauspost/compress/gzip: ~450ms
- compress/gzip: ~1250ms

There appears to be no penalty to using pgzip in this context (as tested by setting GOMAXPROCS=1).

This branch switches from compress/gzip to github.com/klauspost/pgzip.